### PR TITLE
Remove redundant Lombok annotations

### DIFF
--- a/src/main/java/com/example/persona/dto/UserPersonaResponseDTO.java
+++ b/src/main/java/com/example/persona/dto/UserPersonaResponseDTO.java
@@ -1,17 +1,14 @@
 package com.example.persona.dto;
 
 import com.example.persona.model.UserPersona;
-import lombok.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.Instant;
 import java.time.LocalDate;
 
-@Getter
-@Setter
-@ToString
-@NoArgsConstructor
-@AllArgsConstructor
 @Data
+@NoArgsConstructor
 public class UserPersonaResponseDTO {
     private Long c_ID;
     private String zip;


### PR DESCRIPTION
## Summary
- simplify `UserPersonaResponseDTO` by only using Lombok `@Data`
- keep `@NoArgsConstructor` to maintain default constructor

## Testing
- `./mvnw -q test` *(fails: could not download Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_686d51516bb48323aa6dbc611d635b62