### PR TITLE
Fix signup date handling

### DIFF
--- a/src/main/java/com/example/persona/dto/UserPersonaRequestDTO.java
+++ b/src/main/java/com/example/persona/dto/UserPersonaRequestDTO.java
@@ -1,6 +1,5 @@
 package com.example.persona.dto;
 
-import jakarta.persistence.Entity;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
@@ -17,9 +16,9 @@ public class UserPersonaRequestDTO {
     private String email;
     private String name;
     private String role;
-    private LocalDate dob;
+    private LocalDate dateOfBirth;
     private String gender;
-    private LocalDateTime signupDate;
+    private LocalDateTime signUpDate;
     private LocalDateTime lastLoginDate;
     private String phone;
     private String address1;

--- a/src/main/java/com/example/persona/service/UserPersonaService.java
+++ b/src/main/java/com/example/persona/service/UserPersonaService.java
@@ -5,6 +5,8 @@ import com.example.persona.model.UserPersona;
 import com.example.persona.repository.UserPersonaRepository;
 import org.springframework.stereotype.Service;
 
+import java.time.ZoneOffset;
+
 @Service
 public class UserPersonaService {
 
@@ -32,10 +34,10 @@ public class UserPersonaService {
                 .email(dto.getEmail())
                 .name(dto.getName())
                 .role(dto.getRole())
-                .dob(dto.getDob())
+                .dateOfBirth(dto.getDateOfBirth())
                 .gender(dto.getGender())
-                .signupDate(dto.getSignupDate())
-                .lastLoginDate(dto.getLastLoginDate())
+                .signUpDate(dto.getSignUpDate().toInstant(ZoneOffset.UTC))
+                .lastLoginDate(dto.getLastLoginDate() == null ? null : dto.getLastLoginDate().toInstant(ZoneOffset.UTC))
                 .phone(dto.getPhone())
                 .address1(dto.getAddress1())
                 .address2(dto.getAddress2())


### PR DESCRIPTION
## Summary
- rename request fields for signUpDate/dateOfBirth
- convert signUpDate and lastLoginDate to Instant in service
- call new builder methods

## Testing
- `mvnw test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_686d515863688323bbe67aed8f455e08